### PR TITLE
Attendance data filtering and ability to pull meta.

### DIFF
--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -3,8 +3,6 @@ import type { AxiosRequestConfig, AxiosInstance } from "axios";
 import type {
   ActivityResponse,
   AnnouncementsResponse,
-  AttendanceDate,
-  AttendanceResponse,
   AttendanceScheme,
   BadgesResponse,
   BehaviourResponse,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+export interface ResponseFormat {
+  success?: number;
+  expired?: number;
+  error?: string;
+  data: Record<string, unknown> | Array<object> | any;
+  meta: Record<string, unknown> | Array<object> | any;
+}
+export type SuccessResponse = Pick<ResponseFormat, "success" | "data" | "meta">;
+export type ErrorResponse = Omit<ResponseFormat, "data">;
+
 export interface Student {
   id: number;
   name: string;
@@ -310,18 +320,36 @@ export interface GetFullActivityOptions {
    */
   to: string;
 }
-
+export interface AttendanceMeta {
+  dates: Array<string>;
+  end_date: string;
+  percentage: string;
+  percentage_singe_august: string;
+  sessions: Array<string>;
+  start_date: string;
+}
+export interface GetAttendanceOptions {
+    /**
+   * From date, in format YYYY-MM-DD
+   */
+     from: string;
+     /**
+      * To date, in format YYYY-MM-DD
+      */
+     to: string;
+}
+export type AttendanceStatus = "present" | "ignore" | "absent" | "excused";
 export interface AttendanceDate {
   AM: {
     code: string;
-    status: "present" | "ignore";
+    status: AttendanceStatus;
     late_minutes: number;
   };
   PM: {
     code: string;
-    status: "present" | "ignore";
+    status: AttendanceStatus;
     late_minutes: number;
   };
 }
-
+export type AttendanceScheme = { data: AttendanceDate; meta: AttendanceMeta };
 export type AttendanceResponse = Array<Record<string, AttendanceDate>>;


### PR DESCRIPTION
the `listAttendance()` function now takes an optional `options` parameter for dates to filter by. `from` and `to` are used to depict the data range. Straight forward stuff ;)

Also, I've added the ability to return meta on request. If an `includeMeta` parameter in the `makeAuthedRequest()` function is passed as true, then the function will instead return a object containing `data` and now `meta`. If false, will just return the standard data response.