### PR TITLE
feat: migrate to parsing cookies properly

### DIFF
--- a/src/parentClient.ts
+++ b/src/parentClient.ts
@@ -54,9 +54,9 @@ export class ClasschartsParentClient extends ClasschartsClient {
 
     const cookies = String(request.headers["set-cookie"]);
     this.authCookies = cookies.split(";");
-    const sessionCookie = parseCookies(cookies);
+    const sessionCookies = parseCookies(cookies);
     const sessionID = JSON.parse(
-      String(sessionCookie["student_session_credentials"])
+      String(sessionCookies["parent_session_credentials"])
     );
     this.sessionId = sessionID.session_id;
     this.pupils = await this.getPupils();

--- a/src/parentClient.ts
+++ b/src/parentClient.ts
@@ -3,6 +3,7 @@ import type { GetPupilsResponse } from "./types";
 
 import { ClasschartsClient } from "./baseClient";
 import { API_BASE_PARENT, BASE_URL } from "./consts";
+import { parseCookies } from "./utils";
 /**
  * The base client
  */
@@ -51,18 +52,11 @@ export class ClasschartsParentClient extends ClasschartsClient {
     if (request.status != 302 || !request.headers["set-cookie"])
       throw new Error("Unauthenticated: Classcharts returned an error");
 
-    const cookies = request.headers["set-cookie"];
-    for (let i = 0; i < cookies.length; i++) {
-      cookies[i] = cookies[i].substring(0, cookies[i].indexOf(";"));
-    }
-
-    this.authCookies = cookies;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let sessionID: any = decodeURI(cookies[1])
-      .replace(/%3A/g, ":")
-      .replace(/%2C/g, ",");
-    sessionID = JSON.parse(
-      sessionID.substring(sessionID.indexOf("{"), sessionID.length)
+    const cookies = String(request.headers["set-cookie"]);
+    this.authCookies = cookies.split(";");
+    const sessionCookie = parseCookies(cookies);
+    const sessionID = JSON.parse(
+      String(sessionCookie["student_session_credentials"])
     );
     this.sessionId = sessionID.session_id;
     this.pupils = await this.getPupils();

--- a/src/studentClient.ts
+++ b/src/studentClient.ts
@@ -1,6 +1,7 @@
 import type { AxiosRequestConfig } from "axios";
 import { API_BASE_STUDENT, BASE_URL } from "./consts";
 import { ClasschartsClient } from "./baseClient";
+import { parseCookies } from "./utils";
 /**
  * The base client
  */
@@ -47,17 +48,11 @@ export class ClasschartsStudentClient extends ClasschartsClient {
     });
     if (request.status != 302 || !request.headers["set-cookie"])
       throw new Error("Unauthenticated: Classcharts returned an error");
-    const cookies = request.headers["set-cookie"];
-    for (let i = 0; i < cookies.length; i++) {
-      cookies[i] = cookies[i].substring(0, cookies[i].indexOf(";"));
-    }
-    this.authCookies = cookies;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let sessionID: any = decodeURI(cookies[1])
-      .replace(/%3A/g, ":")
-      .replace(/%2C/g, ",");
-    sessionID = JSON.parse(
-      sessionID.substring(sessionID.indexOf("{"), sessionID.length)
+    const cookies = String(request.headers["set-cookie"]);
+    this.authCookies = cookies.split(";");
+    const sessionCookie = parseCookies(cookies);
+    const sessionID = JSON.parse(
+      String(sessionCookie["student_session_credentials"])
     );
     this.sessionId = sessionID.session_id;
     const user = await this.getStudentInfo();

--- a/src/studentClient.ts
+++ b/src/studentClient.ts
@@ -50,9 +50,9 @@ export class ClasschartsStudentClient extends ClasschartsClient {
       throw new Error("Unauthenticated: Classcharts returned an error");
     const cookies = String(request.headers["set-cookie"]);
     this.authCookies = cookies.split(";");
-    const sessionCookie = parseCookies(cookies);
+    const sessionCookies = parseCookies(cookies);
     const sessionID = JSON.parse(
-      String(sessionCookie["student_session_credentials"])
+      String(sessionCookies["student_session_credentials"])
     );
     this.sessionId = sessionID.session_id;
     const user = await this.getStudentInfo();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+export function parseCookies(input: string) {
+  const output: Record<string, unknown> = {};
+  const cookies = input.split(",");
+  for (const cookie of cookies) {
+    const cookieSplit = cookie.split(";")[0].split("=");
+    output[decodeURIComponent(cookieSplit[0])] = decodeURIComponent(
+      cookieSplit[1]
+    );
+  }
+  return output;
+}


### PR DESCRIPTION
Use the name of cookies explicitly, instead of relying on the order. Prevents issues when the cookie order changes (e.g. 80c3f6565e586589aa0e51f72aa98f88949802cd)