### PR TITLE
Create ParentClient tests

### DIFF
--- a/src/core/parentClient.ts
+++ b/src/core/parentClient.ts
@@ -26,6 +26,7 @@ export class ParentClient extends BaseClient {
    */
   async login(): Promise<void> {
     if (!this.email) throw new Error("Email not provided");
+    if (!this.password) throw new Error("Password not provided");
     const formData = new URLSearchParams();
     formData.append("_method", "POST");
     formData.append("email", this.email);
@@ -42,11 +43,9 @@ export class ParentClient extends BaseClient {
       redirect: "manual",
     });
     if (response.status != 302 || !response.headers.has("set-cookie")) {
+      await response.body?.cancel(); // Make deno tests happy by closing the body, unsure whether this is needed for the actual library
       throw new Error(
-        "Unauthenticated: ClassCharts returned an error: " +
-          response.status +
-          " " +
-          response.statusText,
+        "Unauthenticated: ClassCharts didn't return authentication cookies"
       );
     }
 

--- a/src/core/parentClient.ts
+++ b/src/core/parentClient.ts
@@ -45,7 +45,7 @@ export class ParentClient extends BaseClient {
     if (response.status != 302 || !response.headers.has("set-cookie")) {
       await response.body?.cancel(); // Make deno tests happy by closing the body, unsure whether this is needed for the actual library
       throw new Error(
-        "Unauthenticated: ClassCharts didn't return authentication cookies"
+        "Unauthenticated: ClassCharts didn't return authentication cookies",
       );
     }
 

--- a/src/core/parentClient_test.ts
+++ b/src/core/parentClient_test.ts
@@ -12,7 +12,6 @@ Deno.test("Throws when no email is provided", async () => {
   );
 });
 
-// throws when no password is provided
 Deno.test("Throws when no password is provided", async () => {
   const client = new ParentClient("email", "");
   await assertRejects(
@@ -24,7 +23,7 @@ Deno.test("Throws when no password is provided", async () => {
   );
 });
 
-Deno.test("Throws with invalid login", async () => {
+Deno.test("Throws with invalid username and password", async () => {
   const client = new ParentClient("invalid", "invalid");
   await assertRejects(
     async () => {

--- a/src/core/parentClient_test.ts
+++ b/src/core/parentClient_test.ts
@@ -2,7 +2,7 @@ import { assertRejects } from "~/deps_dev.ts";
 import { ParentClient } from "~/src/core/parentClient.ts";
 
 Deno.test("Throws when no email is provided", async () => {
-  const client = new ParentClient("","password");
+  const client = new ParentClient("", "password");
   await assertRejects(
     async () => {
       await client.login();
@@ -14,25 +14,23 @@ Deno.test("Throws when no email is provided", async () => {
 
 // throws when no password is provided
 Deno.test("Throws when no password is provided", async () => {
-    const client = new ParentClient("email","");
-    await assertRejects(
-        async () => {
-        await client.login();
-        },
-        Error,
-        "Password not provided",
-    );
-    }
-);
+  const client = new ParentClient("email", "");
+  await assertRejects(
+    async () => {
+      await client.login();
+    },
+    Error,
+    "Password not provided",
+  );
+});
 
 Deno.test("Throws with invalid login", async () => {
-    const client = new ParentClient("invalid","invalid");
-    await assertRejects(
-      async () => {
-        await client.login();
-      },
-      Error,
-      "Unauthenticated: ClassCharts didn't return authentication cookies",
-    );
-  });
-  
+  const client = new ParentClient("invalid", "invalid");
+  await assertRejects(
+    async () => {
+      await client.login();
+    },
+    Error,
+    "Unauthenticated: ClassCharts didn't return authentication cookies",
+  );
+});

--- a/src/core/parentClient_test.ts
+++ b/src/core/parentClient_test.ts
@@ -1,0 +1,38 @@
+import { assertRejects } from "~/deps_dev.ts";
+import { ParentClient } from "~/src/core/parentClient.ts";
+
+Deno.test("Throws when no email is provided", async () => {
+  const client = new ParentClient("","password");
+  await assertRejects(
+    async () => {
+      await client.login();
+    },
+    Error,
+    "Email not provided",
+  );
+});
+
+// throws when no password is provided
+Deno.test("Throws when no password is provided", async () => {
+    const client = new ParentClient("email","");
+    await assertRejects(
+        async () => {
+        await client.login();
+        },
+        Error,
+        "Password not provided",
+    );
+    }
+);
+
+Deno.test("Throws with invalid login", async () => {
+    const client = new ParentClient("invalid","invalid");
+    await assertRejects(
+      async () => {
+        await client.login();
+      },
+      Error,
+      "Unauthenticated: ClassCharts didn't return authentication cookies",
+    );
+  });
+  


### PR DESCRIPTION
Here are some tests for the parent client.

I have also made 2 changes, one that changes the unauthenticated error message to be the same as the one for the student client, and one for a missing password.