### PR TITLE
fix: get all Set-Cookie headers to support both cookies

### DIFF
--- a/src/core/baseClient.ts
+++ b/src/core/baseClient.ts
@@ -96,7 +96,7 @@ export abstract class BaseClient {
 		const requestOptions = {
 			...fetchOptions,
 			headers: {
-				Cookie: this?.authCookies?.join(";") ?? [],
+				Cookie: this?.authCookies?.join("; ") ?? [],
 				Authorization: `Basic ${this.sessionId}`,
 				"User-Agent":
 					"classcharts-api https://github.com/classchartsapi/classcharts-api-js",

--- a/src/core/parentClient.ts
+++ b/src/core/parentClient.ts
@@ -61,11 +61,23 @@ export class ParentClient extends BaseClient {
 			);
 		}
 
-		const cookies = String(response.headers.get("set-cookie"));
-		// this.authCookies = cookies.split(";");
-		const sessionCookies = parseCookies(cookies);
+		// Get ALL Set-Cookie headers (get() only returns the first one!)
+		const setCookieHeaders = response.headers.getSetCookie();
+		if (!setCookieHeaders || setCookieHeaders.length < 2) {
+			await response.body?.cancel();
+			throw new Error("Unauthenticated: Missing Set-Cookie headers");
+		}
+
+		// Parse both cookies
+		const cookie1 = parseCookies(setCookieHeaders[0]);
+		const cookie2 = parseCookies(setCookieHeaders[1]);
+
+		// Store only the name=value portion of each Set-Cookie header
+		this.authCookies = setCookieHeaders.map((h) => h.split(";")[0].trim());
+
+		// Get session ID from parent_session_credentials cookie
 		const sessionID = JSON.parse(
-			String(sessionCookies.parent_session_credentials),
+			String(cookie1.parent_session_credentials || cookie2.parent_session_credentials),
 		);
 		this.sessionId = sessionID.session_id;
 		this.pupils = await this.getPupils();


### PR DESCRIPTION
ClassCharts returns two cookies on login (cc-session and parent_session_credentials), but response.headers.get('set-cookie') only returns the first one. This fix uses getSetCookie() to get both.